### PR TITLE
only ignore schema instead of whole db directory

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -7,7 +7,7 @@ AllCops:
     - '*.gemspec'
     - 'bin/**/*'
     - 'data/**/*'
-    - 'db/**/*'
+    - 'db/schema.rb'
     - 'lib/tasks/circle_0.rake' # Ignore circleci code
     - 'log/**/*'
     - 'public/**/*'

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = "0.1.1".freeze
+    VERSION = "0.1.2".freeze
   end
 end


### PR DESCRIPTION
we still want to validate migration files + seeds by default

schema.rb is autogenerated code, so that should always be ignored