### PR TITLE
Upgrade to Rubocop 0.57

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,6 @@ jobs:
       - run: bundle exec bundle-audit update && bundle exec bundle-audit check
       - run: bundle exec rubocop --config=default.yml
       - run:
-          name: Check `default.yml` for warnings
-          command: ! bundle exec rubocop --config=default.yml 2>&1 | grep 'Warning:'
+          name: Check default.yml for warnings
+          command: "! bundle exec rubocop --config=default.yml 2>&1 | grep 'Warning:'"
       - run: bundle exec rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,4 +11,7 @@ jobs:
       - run: bundle install --jobs=4 --retry=3 --path vendor/bundle
       - run: bundle exec bundle-audit update && bundle exec bundle-audit check
       - run: bundle exec rubocop --config=default.yml
+      - run:
+          name: Check `default.yml` for warnings
+          command: ! bundle exec rubocop --config=default.yml 2>&1 | grep 'Warning:'
       - run: bundle exec rspec

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = "0.1.3".freeze
+    VERSION = "0.2.0".freeze
   end
 end

--- a/ws-style.gemspec
+++ b/ws-style.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.49"
+  spec.add_dependency "rubocop", "~> 0.57"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
We are currently quite behind in the Rubocop game, still on version `0.49.x`.

This PR upgrades our dependency to the latest version, `0.57.x`.

By trying a few of our internal projects, I only found a couple of cops that needed to be fixed:

```ruby
application_helper_spec.rb:38: W: Lint/BigDecimalNew: BigDecimal.new() is deprecated. Use BigDecimal() instead.
        expect(Money).to receive(:from_amount).with(BigDecimal.new('0'), 'USD').and_return(Money.zero('USD'))
                                                               ^^^
rails_helper.rb:5: C: Style/ExpandPathArguments: Use expand_path('../config/environment', __dir__) instead of expand_path('../../config/environment', __FILE__).
        require File.expand_path('../../config/environment', __FILE__)
```

The transition shouldn't be too bad.