### PR TITLE
Enforce consistent style for array indentation

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -23,6 +23,9 @@ Layout/ExtraSpacing:
 Layout/IndentHash:
   Enabled: false
 
+Layout/IndentArray:
+  EnforcedStyle: consistent
+
 Layout/MultilineMethodCallIndentation:
   Enabled: false
 

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = "0.1.3".freeze
+    VERSION = "0.1.4".freeze
   end
 end

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = "0.1.4".freeze
+    VERSION = "0.2.0".freeze
   end
 end


### PR DESCRIPTION
### Why
By default, the enforced style for this rule is `special_inside_parentheses`: 
```ruby
array = [
  :value
]
but_in_a_method_call([
                       :its_like_this
                     ])
```

I don't think I'm alone in finding this formatting not only unsightly, but also a pain to try and achieve in your text editor. Most importantly, it is inconsistent with how our Javascript code is formatted.

### What
My proposal is to change the enforced style to `consistent`:

```ruby
array = [
  :value
]
and_in_a_method_call([
  :no_difference
])
```

This change can easily be applied across our projects using RuboCop's `--fix` option.

More info: https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/IndentArray