### PR TITLE
[skip ci] Add PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+#### Why <!-- A short description of why this change is required -->
+
+
+
+#### What changed <!-- Summary of changes when modifying hundreds of lines -->
+
+
+
+<!--
+Consider adding the following sections:
+
+#### How I tested [ Bullets for test cases covered ]
+#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
+#### Screenshot [ An image is worth a thousand words ]
+#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
+-->


### PR DESCRIPTION
#### Why

* From time to time people have to look back into pull requests, they often do not find enough description to understand why the change was introduced.
* Sometimes the PR is a dead end.
* Visual changes are hard to code review.

We want our pull requests to provide good historical breadcrumbs as of why a change was introduced.
By introducing a template we hope that the quality of the description will increase, meaning less dead ends.

#### What changed

Add pull request template as proposed by https://wealthsimple.quip.com/tjIcARUqieZQ/RFC-Standardize-pull-request-template
