### PR TITLE
add extra exclude paths

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -8,6 +8,7 @@ AllCops:
     - 'bin/**/*'
     - 'data/**/*'
     - 'db/schema.rb'
+    - 'gemfiles/**/*'
     - 'lib/tasks/circle_0.rake' # Ignore circleci code
     - 'log/**/*'
     - 'public/**/*'


### PR DESCRIPTION
exclude appraisal created gemfiles by default. this is for the same
reason we exclude the actual gemfile/gemspec files