### PR TITLE
Use trailing dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 - 2019-02-12
+### Changed
+- Use trailing dots for multiline chained method invocations. This prevents bugs when pasting Ruby snippets into REPLs.
+
 ## 0.4.7 - 2019-01-07
 ### Added
 - Changelog file: human readable history.

--- a/default.yml
+++ b/default.yml
@@ -24,8 +24,8 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*'
 
-Layout/IndentArray:
-  EnforcedStyle: consistent
+Layout/DotPosition:
+  EnforcedStyle: trailing
 
 Layout/CaseIndentation:
   Enabled: false
@@ -35,6 +35,9 @@ Layout/ElseAlignment:
 
 Layout/EndAlignment:
   Enabled: false
+
+Layout/IndentArray:
+  EnforcedStyle: consistent
 
 Layout/IndentationWidth:
   Enabled: false

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '1.0.0'.freeze
+    VERSION = '2.0.0'.freeze
   end
 end

--- a/spec/ws/version_spec.rb
+++ b/spec/ws/version_spec.rb
@@ -1,10 +1,10 @@
 describe Ws::Style do
   def get_version(git, branch = 'HEAD')
-    git.grep('VERSION = ', 'lib/*/version.rb', { object: branch })
-      .map { |_sha, matches| matches.first[1] }
-      .map(&method(:parse_version))
-      .reject(&:nil?)
-      .first
+    git.grep('VERSION = ', 'lib/*/version.rb', { object: branch }).
+      map { |_sha, matches| matches.first[1] }.
+      map(&method(:parse_version)).
+      reject(&:nil?).
+      first
   end
 
   def parse_version(string)


### PR DESCRIPTION
There's a [long discussion](https://github.com/rubocop-hq/ruby-style-guide/pull/176#issuecomment-20421523) in the Rubocop community around this and the consensus is to "be consistent", no matter if you choose trailing or leading dots.

At Wealthsimple there's a considerable disadvantage to using leading dots: code with leading dots cannot be pasted into irb/pry. This affects local testing and scripting.

We'd had bugs in the past related to people pasting large snippets from a perfectly functioning Ruby file into pry, but that script fails very subtly, amidst hundreds of successfully pasted lines, one fails but the whole block is still successful.
Example:
```ruby
# a lot of code here
list = bar.map{|x|x+1}
         .select{|x|x>1}
# much more code here
```
this code still "works", but will give you incorrect results.