### PR TITLE
configure rspec-rubocop defaults

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,6 +1,8 @@
 # See documentation for details on definitions:
 # https://rubocop.readthedocs.io
 
+require: rubocop-rspec
+
 inherit_mode:
   merge:
     - AllowedNames
@@ -136,4 +138,20 @@ Rails/SkipsModelValidations:
 Rails/TimeZone:
   Enabled: false
 
-require: rubocop-rspec
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Max: 15
+
+RSpec/LetSetup:
+  Enabled: false
+
+RSpec/MessageChain:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 4

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '3.0.2'.freeze
+    VERSION = '3.0.3'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
The default rubocop-rspec config is fairly strict. Tweaking them a little so we're not too constricted when adding tests. 

#### What changed <!-- Summary of changes when modifying hundreds of lines -->
Set some basic defaults:

```
RSpec/AnyInstance:
  Enabled: false

RSpec/ExampleLength:
  Max: 15

RSpec/LetSetup:
  Enabled: false

RSpec/MessageChain:
  Enabled: false

RSpec/MultipleExpectations:
  Enabled: false

RSpec/NestedGroups:
  Max: 4
```

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
