### PR TITLE
rubocop 0.67.1 add exception naming cop

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1,6 +1,7 @@
 # See documentation for details on definitions:
 # https://rubocop.readthedocs.io
 
+require: rubocop-performance
 require: rubocop-rspec
 
 inherit_mode:
@@ -79,10 +80,6 @@ Metrics/ParameterLists:
 
 Metrics/PerceivedComplexity:
   Max: 8
-
-Naming/UncommunicativeMethodParamName:
-  AllowedNames:
-    - ex
 
 Style/AndOr:
   EnforcedStyle: conditionals

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '3.0.5'.freeze
+    VERSION = '3.1.0'.freeze
   end
 end

--- a/ws-style.gemspec
+++ b/ws-style.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'rubocop', '~> 0.64'
+  s.add_dependency 'rubocop', '>= 0.67.1'
+  s.add_dependency 'rubocop-performance', '>= 1.1.0'
   s.add_dependency 'rubocop-rspec', '~> 1.32'
 
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
rubocop 0.67.1 adds Naming/RescuedExceptionsVariableName which makes the Naming/UncommunicativeMethodParamName modification unnecessary.

The default is e, does someone have a preference between e/ex/exception 🤷‍♂️ 

performance cops have also been migrated out to rubocop-performance
https://github.com/rubocop-hq/rubocop/blob/master/manual/migrate_performance_cops.md

#### What changed <!-- Summary of changes when modifying hundreds of lines -->



<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
