### PR TITLE
fix: Multiple `require` must use a list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.1.1 - 2019-04-09
+### Fixed
+- Correctly require multiple dependencies.
+
 ## 3.0.5 - 2019-04-03
 ### Changed
 - updated README

--- a/default.yml
+++ b/default.yml
@@ -1,8 +1,9 @@
 # See documentation for details on definitions:
 # https://rubocop.readthedocs.io
 
-require: rubocop-performance
-require: rubocop-rspec
+require:
+  - rubocop-performance
+  - rubocop-rspec
 
 inherit_mode:
   merge:

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '3.1.0'.freeze
+    VERSION = '3.1.1'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

The other way of requiring multiple extensions was incorrect resulting in warn message and being ignored.

https://rubocop.readthedocs.io/en/latest/extensions/