### PR TITLE
AlignParamenters is split into Layout/AlignArguments in v0.68

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -30,6 +30,9 @@ Layout/AlignHash:
 Layout/AlignParameters:
   Enabled: false
 
+Layout/AlignArguments:
+  Enabled: false
+
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*'

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '4.1.0'.freeze
+    VERSION = '4.1.1'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
```
Extract method call argument alignment behavior from Layout/AlignParameters into Layout/AlignArguments. (@maxh)
```

#### What changed <!-- Summary of changes when modifying hundreds of lines -->
We disable Layout/AlignParameters to not enforce a specific indentation style for method arguments.
Also disabling the new Layout/AlignArguments.


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
