### PR TITLE
not updating timestamps ends up with missing data on periscope

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -134,9 +134,6 @@ Rails/Date:
 Rails/Delegate:
   Enabled: false
 
-Rails/SkipsModelValidations:
-  Enabled: false
-
 Rails/TimeZone:
   Enabled: false
 

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '4.1.1'.freeze
+    VERSION = '5.0.0'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
Enabling Rails/SkipsModelValidations


#### What changed <!-- Summary of changes when modifying hundreds of lines -->
Rails/SkipsModelValidations prevents used of methods which skip validations or timestamp updates.

Enabling the cop as we want to prevent skipping timestamp updates as that prevents data from syncing over to redis/periscope.

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
