### PR TITLE
rails cops now live in rubocop-rails

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -3,6 +3,7 @@
 
 require:
   - rubocop-performance
+  - rubocop-rails
   - rubocop-rspec
   - rubocop-vendor
 

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '5.2.0'.freeze
+    VERSION = '5.2.1'.freeze
   end
 end

--- a/ws-style.gemspec
+++ b/ws-style.gemspec
@@ -21,8 +21,9 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'rubocop', '>= 0.67.1'
+  s.add_dependency 'rubocop', '>= 0.72'
   s.add_dependency 'rubocop-performance', '>= 1.1.0'
+  s.add_dependency 'rubocop-rails', '>= 2.1.0'
   s.add_dependency 'rubocop-rspec', '~> 1.32'
   s.add_dependency 'rubocop-vendor', '~> 0'
 


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
As of rubocop 0.72 rails cops have been moved to rubocop-rails

https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md

#### What changed <!-- Summary of changes when modifying hundreds of lines -->



<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
