### PR TITLE
relax rspec nested group limit

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -139,6 +139,9 @@ Rails/TimeZone:
 RSpec/AnyInstance:
   Enabled: false
 
+RSpec/ContextWording:
+  Enabled: false
+
 RSpec/EmptyExampleGroup:
   Enabled: false
 
@@ -154,5 +157,8 @@ RSpec/MessageChain:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/NamedSubject:
+  Enabled: false
+
 RSpec/NestedGroups:
-  Max: 4
+  Max: 6

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '5.2.1'.freeze
+    VERSION = '5.2.2'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

On @cabello recoomendation

Disable 
RSpec/ContextWording
RSpec/NamedSubject

as they don't seem to add too much value and are quite troublesome to fix for existing repos.

Relax contraint on RSpec/NestedGroups to 6

#### What changed <!-- Summary of changes when modifying hundreds of lines -->


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
