### PR TITLE
disable NegatedIf

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -130,6 +130,9 @@ Style/TrailingCommaInHashLiteral:
 Style/WordArray:
   Enabled: false
 
+Style/NegatedIf:
+  Enabled: false
+
 Rails:
   Enabled: true
 

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '5.4.2'.freeze
+    VERSION = '5.4.3'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
`unless` is more confusing than `if !`, especially for developers coming to Ruby from other languages.  It does not improve comprehensibility, so we should not enforce the rule.

#### What changed <!-- Summary of changes when modifying hundreds of lines -->
Disabled evil rubocop forcing us to use unless


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
