### PR TITLE
Include cops for db/data for data migrations

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -16,7 +16,8 @@ AllCops:
   Exclude:
     - "bin/**/*"
     - "data/**/*"
-    - "db/**/*"
+    - "db/migrate/**/*"
+    - "db/schema.rb"
     - "gemfiles/**/*"
     - "lib/tasks/circle_0.rake"
     - "log/**/*"

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '5.2.4'.freeze
+    VERSION = '5.2.5'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
employer-service has been using data migrations for a bit now (https://github.com/ilyakatz/data-migrate) in efforts to move away from rcon changes. We'd like to enable linting for these data migration files as well.


#### What changed <!-- Summary of changes when modifying hundreds of lines -->
Instead of excluding everything from the db directory, we now exclude the db/migrate directory and db/schema file


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
