### PR TITLE
Upgrade rubocop to 0.77

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -26,13 +26,13 @@ AllCops:
     - "tmp/**/*"
     - "vendor/**/*"
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedLastArgumentHashStyle: ignore_implicit
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Enabled: false
 
-Layout/AlignArguments:
+Layout/ArgumentAlignment:
   Enabled: false
 
 Lint/AmbiguousBlockAssociation:
@@ -51,14 +51,14 @@ Layout/ElseAlignment:
 Layout/EndAlignment:
   Enabled: false
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 Layout/IndentationWidth:
   Enabled: true
   Width: 2
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 Layout/MultilineMethodCallIndentation:

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '5.2.5'.freeze
+    VERSION = '5.3.0'.freeze
   end
 end

--- a/ws-style.gemspec
+++ b/ws-style.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'rubocop', '>= 0.72'
+  s.add_dependency 'rubocop', '>= 0.77'
   s.add_dependency 'rubocop-performance', '>= 1.1.0'
   s.add_dependency 'rubocop-rails', '>= 2.1.0'
   s.add_dependency 'rubocop-rspec', '~> 1.32'


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
We were looking into adding a helper method in `ws-pact-ruby` (https://github.com/wealthsimple/ws-pact-ruby/pull/27) but had issues passing linter check because `ws-pact-ruby` tried to use the latest version of rubocop (0.77) with the imcompatible configuration file from `ws-style`.


#### What changed <!-- Summary of changes when modifying hundreds of lines -->
* Upgrade rubocop to 0.77
* Fixed cop names that were updated in 0.77 (https://github.com/rubocop-hq/rubocop/commit/6509e440e240f1f6c09249fb1a737a4e6abe90db)


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
