### PR TITLE
fix: cop has been removed

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -96,9 +96,6 @@ Style/AndOr:
 Style/BlockDelimiters:
   Enabled: false
 
-Style/BracesAroundHashParameters:
-  Enabled: false
-
 Style/ClassAndModuleChildren:
   Enabled: false
 

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '5.4.0'.freeze
+    VERSION = '5.4.1'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

```
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
Error: The `Style/BracesAroundHashParameters` cop has been removed.
(obsolete configuration found in vendor/bundle/ruby/2.5.0/gems/ws-style-5.4.0/default.yml, please update it)
```
https://circleci.com/gh/wealthsimple/ws-railway/2395

#### What changed <!-- Summary of changes when modifying hundreds of lines -->



<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
