### PR TITLE
Enable new Rubocops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.0.0 - 2020-04-27
+### Changed
+- Upgraded rubocop to >= 0.82 and opted into the 7 new cops.
+- Going forward we will need to explicitly opt into or out of every new cop.
+
 ## 5.1.0 - 2019-06-06
 ### Changed
 - Added indentation cop, enforcing 2 space indentation.
@@ -27,10 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     end
   end
   ```
-## 6.0.0 - 2020-04-27
-### Changed
-- Upgraded rubocop to >= 0.82 and opted into the 7 new cops.
-- Going forward we will need to explicitly opt into or out of every new cop.
 
 ## 5.0.0 - 2019-05-30
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added indentation cop, enforcing 2 space indentation.
 
   This allows Rubocop to automatically format code like this:
-  
+
   ```ruby
   class Wizard
   def cast_spell
@@ -17,9 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   end
   end
   ```
-  
+
   into this:
-  
+
   ```ruby
   class Wizard
     def cast_spell
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     end
   end
   ```
+## 6.0.0 - 2020-04-27
+### Changed
+- Upgraded rubocop to >= 0.82 and opted into the 7 new cops.
+- Going forward we will need to explicitly opt into or out of every new cop.
 
 ## 5.0.0 - 2019-05-30
 ### Changed

--- a/default.yml
+++ b/default.yml
@@ -169,6 +169,29 @@ RSpec/NamedSubject:
 RSpec/NestedGroups:
   Max: 6
 
-# https://docs.rubocop.org/en/latest/versioning/
-AllCops:
-  NewCops: enable
+# Cops added in Rubocop 0.80 or later need to be enabled one-by-one below.
+# For more information: https://docs.rubocop.org/en/latest/versioning/
+
+# 0.80
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+# 0.81
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+# 0.82
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true

--- a/default.yml
+++ b/default.yml
@@ -168,3 +168,7 @@ RSpec/NamedSubject:
 
 RSpec/NestedGroups:
   Max: 6
+
+# https://docs.rubocop.org/en/latest/versioning/
+AllCops:
+  NewCops: enable

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '5.4.3'.freeze
+    VERSION = '6.0.0'.freeze
   end
 end

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '5.4.2'.freeze
+    VERSION = '5.4.3'.freeze
   end
 end

--- a/ws-style.gemspec
+++ b/ws-style.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'rubocop', '>= 0.79'
+  s.add_dependency 'rubocop', '>= 0.82'
   s.add_dependency 'rubocop-performance', '>= 1.1.0'
   s.add_dependency 'rubocop-rails', '>= 2.4.2'
   s.add_dependency 'rubocop-rspec', '~> 1.32'


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
This opts us into all new cops by default. Otherwise, we'll always get warnings like this when we run `bundle exec rubocop`, asking us to opt into each individual cop: 

```
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file:
 - Layout/SpaceAroundMethodCallOperator (0.82)
 - Lint/RaiseException (0.81)
 - Lint/StructNewOverride (0.81)
 - Style/ExponentialNotation (0.82)
 - Style/HashEachMethods (0.80)
 - Style/HashTransformKeys (0.80)
 - Style/HashTransformValues (0.80)
For more information: https://docs.rubocop.org/en/latest/versioning/
```

#### What changed <!-- Summary of changes when modifying hundreds of lines -->
Modified default.yml to opt us into all new cops – the default behaviour before rubocop 0.80.

# Update
We instead decided to opt into new cops individually. This PR opts us into the new cops from 0.80 to 0.82

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
