### PR TITLE
Upgrade to RuboCop 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.5.0 - 2020-10-26
+- Upgrade RuboCop and RuboCop RSpec
+
 ## 6.4.0 - 2020-10-07
 - Upgrade RuboCop
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,8 @@ task default: :spec
 
 desc 'Print out comments that can be used for a GitHub cop election'
 task :election do # rubocop:disable Rails/RakeEnvironment
-  RuboCop::ConfigLoader.default_configuration.pending_cops.each do |pending_cop|
+  configuration_path = File.expand_path('default.yml', File.dirname(__FILE__))
+  RuboCop::ConfigLoader.load_file(configuration_path).pending_cops.each do |pending_cop|
     base_urls = {
       'layout' => 'https://docs.rubocop.org/rubocop/cops_layout.html#layout',
       'lint' => 'https://docs.rubocop.org/rubocop/cops_lint.html#lint',

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.4.0'.freeze
+    VERSION = '6.5.0'.freeze
   end
 end

--- a/ws-style.gemspec
+++ b/ws-style.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.5.7'
 
-  s.add_dependency 'rubocop', '>= 0.92.0'
+  s.add_dependency 'rubocop', '>= 1.0.0'
   s.add_dependency 'rubocop-performance', '>= 1.8.1'
   s.add_dependency 'rubocop-rails', '>= 2.8.1'
-  s.add_dependency 'rubocop-rspec', '>= 1.43.2'
+  s.add_dependency 'rubocop-rspec', '>= 1.44.1'
   s.add_dependency 'rubocop-vendor', '~> 0'
 
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
#### Why

RuboCop has gone 1.0, let's upgrade!

**Best reviewed commit-by-commit**

Click on the first commit in the pull request and use the <kbd>n</kbd> and <kbd>p</kbd> to navigate between the next and previous commits. Please provide feedback on each commit's message as well as its content.
