### PR TITLE
add rubocop inflector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.6.0 - 2021-01-16
+- Rubocop FilePath should respect ActiveSupport::Inflector config if included
+
 ## 6.5.3 - 2020-12-17
 - Disable extension suggestions
 

--- a/lib/ws/style.rb
+++ b/lib/ws/style.rb
@@ -1,4 +1,5 @@
 require "ws/style/version"
+require "ws/style/inflector"
 
 module Ws
   module Style

--- a/lib/ws/style/inflector.rb
+++ b/lib/ws/style/inflector.rb
@@ -1,0 +1,17 @@
+require 'rubocop-rspec'
+
+module Ws
+  module Style
+    module Inflector
+      def camel_to_snake_case(string)
+        if defined?(ActiveSupport::Inflector)
+          ActiveSupport::Inflector.underscore(string)
+        else
+          super(string)
+        end
+      end
+    end
+  end
+end
+
+::RuboCop::Cop::RSpec::FilePath.prepend Ws::Style::Inflector

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.5.3'.freeze
+    VERSION = '6.6.0'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

For apps with custom inflections e.g 
```
inflect.acronym 'P2P'
```

a class `P2PPayment` would be defined in p2p_payment.rb however the RSpec/FilePath will fail as it does not respect the inflection rule.

This ends up requiring CustomTransforms for each file whose class uses a custom inflection:
```
RSpec/FilePath:
  CustomTransform:
    P2P: p2p
    MaintenanceMode: maintenance_mode
    P2PPayment: p2p_payment
    P2PPayments: p2p_payments
    P2PPromo: p2p_promo
    P2PPromos: p2p_promos
    P2PContact: p2p_contact
```


#### What changed <!-- Summary of changes when modifying hundreds of lines -->
Add rubocop-inflector, which incorporates inflections into the cop.


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
