### PR TITLE
disable rubocop suggesting extentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.5.3 - 2020-12-17
+- Disable extension suggestions
+
 ## 6.5.2 - 2020-12-17
 - Add backstage catalog file + sonarqube project settings
 

--- a/core.yml
+++ b/core.yml
@@ -25,6 +25,7 @@ AllCops:
     - "public/**/*"
     - "tmp/**/*"
     - "vendor/**/*"
+  SuggestExtensions: false
 
 Layout/HashAlignment:
   EnforcedLastArgumentHashStyle: ignore_implicit

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.5.2'.freeze
+    VERSION = '6.5.3'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
rubocop keeps suggesting rubocop-rake which we don't use.


#### What changed <!-- Summary of changes when modifying hundreds of lines -->
Prevent rubocop from automatically suggesting extensions on every run.


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
