### PR TITLE
chore: Remove dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,9 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: "ruby:bundler"
-    directory: "/"
-    update_schedule: "weekly"
-    automerged_updates:
-      - match:
-          dependency_type: "development"
-          update_type: "all"


### PR DESCRIPTION
We are live on depfu now. Removing redundant dependabot config. **Please merge after approving.**