### PR TITLE
disable empty block linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.7.1 - 2021-03-09
+- Disable Lint/EmptyBlock
+
 ## 6.7.0 - 2021-03-05
 - Upgraded rubocop to 1.11.0
 - Upgraded rubocop-performance to 1.10.1

--- a/core.yml
+++ b/core.yml
@@ -353,7 +353,7 @@ Lint/DuplicateRegexpCharacterClassElement:
   Enabled: True
 
 Lint/EmptyBlock:
-  Enabled: True
+  Enabled: False
 
 Lint/ToEnumArguments:
   Enabled: True

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.7.0'.freeze
+    VERSION = '6.7.1'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

Causing false positives for:

```
Ws::Features.flag('instant_250_eft') do
  on {}
  off { return '100' }
end
```

and placeholder spec files:

```
RSpec.describe Types::BaseInterface do
end
```


#### What changed <!-- Summary of changes when modifying hundreds of lines -->
Disable Lint/EmptyBlock


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
