### PR TITLE
Increase Metrics/MethodLength to 25.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 6.7.2 - 2021-03-15
-- Increase Metrics/MethodLength to 50 (1/3 of class length).
+- Increase Metrics/MethodLength to 25 (1/6 of class length).
 
 ## 6.7.1 - 2021-03-09
 - Disable Lint/EmptyBlock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.7.2 - 2021-03-15
+- Increase Metrics/MethodLength to 50 (1/3 of class length).
+
 ## 6.7.1 - 2021-03-09
 - Disable Lint/EmptyBlock
 

--- a/core.yml
+++ b/core.yml
@@ -86,7 +86,7 @@ Metrics/CyclomaticComplexity:
 
 Metrics/MethodLength:
   IgnoredMethods: ["extended"]
-  Max: 15
+  Max: 50
 
 Metrics/ModuleLength:
   Exclude:

--- a/core.yml
+++ b/core.yml
@@ -86,7 +86,7 @@ Metrics/CyclomaticComplexity:
 
 Metrics/MethodLength:
   IgnoredMethods: ["extended"]
-  Max: 50
+  Max: 25
 
 Metrics/ModuleLength:
   Exclude:

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.7.1'.freeze
+    VERSION = '6.7.2'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

This [code](https://github.com/wealthsimple/client-service/pull/1365) is reasonable but requires `# rubocop:disable Metrics/MethodLength` due to strict rules:

```ruby
def call
  log_info('BiometricDocumentUpload [start]')

  if documents_to_upload.empty?
    log_info('BiometricDocumentUpload [stop] - no documents to upload')
    return
  end

  documents_to_upload.each do |document|
    filedata = biometric_provider_client.download_document(document_id: document.external_id)

    if upload_to_shareowner?
      log_info('BiometricDocumentUpload [info] - Uploading to shareowner')
      so_documents_client.upload_document(
        identity_id: identity_id,
        document: document,
        filedata: filedata,
      )
    end

    log_info('BiometricDocumentUpload [info] - Uploading to document service')
    document_service_client.upload_document(
      identity_id: identity_id,
      filename: "onfido_#{document.external_id}.#{document.file_type}",
      filedata: filedata,
    )
  end

  log_info('BiometricDocumentupload [done]')
end
```

Yes there is a way to reduce this by extracting a method for the `each` block, still, this is not super complex, 4 calls to log, 3 calls to services.

#### What changed <!-- Summary of changes when modifying hundreds of lines -->

MethodLength rule was increased to 25 (up from 15).

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
