### PR TITLE
Update MethodLength

### DIFF
--- a/core.yml
+++ b/core.yml
@@ -86,7 +86,7 @@ Metrics/CyclomaticComplexity:
 
 Metrics/MethodLength:
   IgnoredMethods: ["extended"]
-  Max: 15
+  Max: 25
 
 Metrics/ModuleLength:
   Exclude:


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
The current method length of 15 seems a bit too small for some reasonably sized methods and it ends up being disabled.

#### What changed <!-- Summary of changes when modifying hundreds of lines -->
Updated `Metrics/MethodLength` from 15 to 25. 
I picked 25 because looking through client-service it seemed like that would catch most of the spots where we're disabling it 

When I set `MethodLength` to 20, it solved for 11 out of the 22 places that we disabled it.
When I set `MethodLength` to 25, it solved for 17 out of the 22 places that we disabled it and the other 5 did seem like exceptionally long methods. 

I'd be open to other suggestions for length though.

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
