### PR TITLE
Upgrade RuboCop dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.9.0 - 2021-04-06
+- Upgraded rubocop to 1.12.1
+- Upgraded rubocop-performance to 1.10.2
+- Upgraded rubocop-vendor to 0.6.0
+
 ## 6.8.9 - 2021-04-02
 - Set minimum required ruby version to 2.7.2
 

--- a/core.yml
+++ b/core.yml
@@ -463,3 +463,7 @@ Performance/RedundantEqualityComparisonBlock:
 
 Performance/RedundantSplitRegexpArgument:
   Enabled: True
+
+# rubocop 1.12.0
+Style/StringChars:
+  Enabled: True

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.7.2'.freeze
+    VERSION = '6.9.0'.freeze
   end
 end

--- a/ws-style.gemspec
+++ b/ws-style.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.7.2'
 
-  s.add_dependency 'rubocop', '>= 1.11.0'
-  s.add_dependency 'rubocop-performance', '>= 1.10.1'
+  s.add_dependency 'rubocop', '>= 1.12.1'
+  s.add_dependency 'rubocop-performance', '>= 1.10.2'
   s.add_dependency 'rubocop-rails', '>= 2.9.1'
   s.add_dependency 'rubocop-rspec', '>= 2.2.0'
-  s.add_dependency 'rubocop-vendor', '>= 0.5.0'
+  s.add_dependency 'rubocop-vendor', '>= 0.6.0'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'bundler-audit'


### PR DESCRIPTION
There is only one new cop.

[**Style/StringChars**](https://docs.rubocop.org/rubocop/cops_style.html#stylestringchars)
Checks for uses of `String#split` with empty string or regexp literal argument.

```ruby
# bad
string.split(//)
string.split('')

# good
string.chars
```
