### PR TITLE
Migrate default branch to main

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,8 +12,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
           bundler-cache: true
+      - name: Fetch main branch
+        run: git fetch origin main
       - uses: r7kamura/rubocop-problem-matchers-action@v1
       - uses: wealthsimple/toolbox-script@main
         name: RuboCop
@@ -22,7 +23,7 @@ jobs:
       - name: Run rspec
         run: bundle exec rspec
       - name: Release the gem
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           mkdir -p ~/.gem
           cat << EOF > ~/.gem/credentials

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.9.1 - 2021-05-06
+- Migrate CI from CircleCI to GitHub Actions
+- Change default GitHub branch to `main`
+
 ## 6.9.0 - 2021-04-06
 - Upgraded rubocop to 1.12.1
 - Upgraded rubocop-performance to 1.10.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.9.0)
+    ws-style (6.9.1)
       rubocop (>= 1.12.1)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,6 @@ GEM
       thor (>= 0.18, < 2)
     concurrent-ruby (1.1.8)
     diff-lcs (1.4.4)
-    docile (1.3.5)
     git (1.8.1)
       rchardet (~> 1.8)
     i18n (1.8.10)
@@ -79,12 +78,6 @@ GEM
     rubocop-vendor (0.6.0)
       rubocop (>= 0.53.0)
     ruby-progressbar (1.11.0)
-    simplecov (0.21.2)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.3)
     thor (0.20.3)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -101,7 +94,6 @@ DEPENDENCIES
   keepachangelog
   rake
   rspec (~> 3.10.0)
-  simplecov
   ws-style!
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,108 @@
+PATH
+  remote: .
+  specs:
+    ws-style (6.9.0)
+      rubocop (>= 1.12.1)
+      rubocop-performance (>= 1.10.2)
+      rubocop-rails (>= 2.9.1)
+      rubocop-rspec (>= 2.2.0)
+      rubocop-vendor (>= 0.6.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.1.3.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    ast (2.4.2)
+    bundler-audit (0.7.0.1)
+      bundler (>= 1.2.0, < 3)
+      thor (>= 0.18, < 2)
+    concurrent-ruby (1.1.8)
+    diff-lcs (1.4.4)
+    docile (1.3.5)
+    git (1.8.1)
+      rchardet (~> 1.8)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    json (2.5.1)
+    keepachangelog (0.6.1)
+      json (~> 2.1)
+      thor (~> 0.20)
+    minitest (5.14.4)
+    parallel (1.20.1)
+    parser (3.0.1.1)
+      ast (~> 2.4.1)
+    rack (2.2.3)
+    rainbow (3.0.0)
+    rake (13.0.3)
+    rchardet (1.8.0)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rubocop (1.14.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.5.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.5.0)
+      parser (>= 3.0.1.1)
+    rubocop-performance (1.11.3)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.10.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.7.0, < 2.0)
+    rubocop-rspec (2.3.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
+    rubocop-vendor (0.6.0)
+      rubocop (>= 0.53.0)
+    ruby-progressbar (1.11.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
+    thor (0.20.3)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.0.0)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler
+  bundler-audit
+  git
+  keepachangelog
+  rake
+  rspec (~> 3.10.0)
+  simplecov
+  ws-style!
+
+BUNDLED WITH
+   2.2.16

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# ws-style [![CircleCI](https://circleci.com/gh/wealthsimple/ws-style.svg?style=svg)](https://circleci.com/gh/wealthsimple/ws-style) [![Gem Version](https://badge.fury.io/rb/ws-style.svg)](https://rubygems.org/gems/ws-style)
+# ws-style
+[![Github Actions Badge](https://github.com/wealthsimple/ws-style/actions/workflows/pipeline.yml/badge.svg)](https://github.com/wealthsimple/ws-style/actions)
 
 Shared [rubocop](https://github.com/bbatsov/rubocop) config to enforce Ruby style consistently across Wealthsimple libraries and services.
 

--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 
-New versions are automatically released by CI when merged to `master`.
+New versions are automatically released by CI when merged to `main`.

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.9.0'.freeze
+    VERSION = '6.9.1'.freeze
   end
 end

--- a/spec/ws/style_spec.rb
+++ b/spec/ws/style_spec.rb
@@ -3,7 +3,7 @@ require 'keepachangelog'
 
 RSpec.describe 'a published gem' do # rubocop:disable RSpec/DescribeClass
   def get_version(git, branch = 'HEAD')
-    git.grep('STRING = ', 'lib/**/version.rb', object: branch).
+    git.grep('VERSION = ', 'lib/**/version.rb', object: branch).
       map { |_sha, matches| matches.first[1] }.
       map { |v| parse_version(v) }.
       compact.
@@ -11,7 +11,7 @@ RSpec.describe 'a published gem' do # rubocop:disable RSpec/DescribeClass
   end
 
   def parse_version(string)
-    string.match(/STRING = ['"](.*)['"]/)[1]
+    string.match(/VERSION = ['"](.*)['"]/)[1]
   end
 
   let(:git) { Git.open('.') }

--- a/spec/ws/style_spec.rb
+++ b/spec/ws/style_spec.rb
@@ -1,5 +1,41 @@
-describe Ws::Style do
+require 'git'
+require 'keepachangelog'
+
+RSpec.describe 'a published gem' do # rubocop:disable RSpec/DescribeClass
+  def get_version(git, branch = 'HEAD')
+    git.grep('STRING = ', 'lib/**/version.rb', object: branch).
+      map { |_sha, matches| matches.first[1] }.
+      map { |v| parse_version(v) }.
+      compact.
+      first
+  end
+
+  def parse_version(string)
+    string.match(/STRING = ['"](.*)['"]/)[1]
+  end
+
+  let(:git) { Git.open('.') }
+  let(:head_version) { get_version(git, 'HEAD') }
+  let(:main_version) { get_version(git, 'origin/main') }
+
   it 'has a version number' do
-    expect(described_class::VERSION).not_to be_nil
+    expect(head_version).not_to be_nil
+  end
+
+  it 'has a bumped version committed' do
+    is_main_branch = git.current_branch == 'main' || main_version.nil?
+    skip('already on main branch, no need to compare versions') if is_main_branch
+
+    expect(Gem::Version.new(head_version)).to be > Gem::Version.new(main_version)
+  end
+
+  it 'has a CHANGELOG.md file' do
+    expect(File).to exist('CHANGELOG.md')
+  end
+
+  it 'has changelog entry for current version' do
+    parser = Keepachangelog::MarkdownParser.load('CHANGELOG.md')
+
+    expect(parser.parsed_content['versions'].keys).to include(start_with("#{head_version} - "))
   end
 end

--- a/ws-style.gemspec
+++ b/ws-style.gemspec
@@ -30,6 +30,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'bundler-audit'
+  s.add_development_dependency 'git'
+  s.add_development_dependency 'keepachangelog'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.10.0'
+  s.add_development_dependency 'simplecov'
 end

--- a/ws-style.gemspec
+++ b/ws-style.gemspec
@@ -34,5 +34,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'keepachangelog'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.10.0'
-  s.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
#### What changed <!-- Summary of changes when modifying hundreds of lines -->
- use `main` as default branch name instead of `master`.
- specs that verify the version has been bumped, just like ~all~ most of our other gems.

Once approved, I will [rename the branch from `master` to `main` on GitHub](https://docs.github.com/en/github/administering-a-repository/renaming-a-branch) before merging.



#### Important

If you have checked out the repository locally before the default branch has been renamed, it will need to be updated like so:

```bash
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

for your convenience, consider putting these into a function in your shell configuration, so you can easily update any other repositories that get updated as well.

```bash
# ~/.bash_profile or ~/.zshrc
function git_migrate_to_main() {
  git branch -m master main
  git fetch origin
  git branch -u origin/main main
  git remote set-head origin -a
}
```


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
