### PR TITLE
Add cuncurrency to GitHub Actions workflow

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,6 +2,10 @@
 name: Pipeline
 on:
   - push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.11.2 - 2021-11-19
+### Changed
+- Add concurrenty to GitHub Actions workflow
+
 ## 6.11.1 - 2021-11-08
 ### Changed
 - Upgrade dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.11.1)
+    ws-style (6.11.2)
       rubocop (>= 1.12.1)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)
@@ -54,7 +54,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.3)
-    rubocop (1.22.3)
+    rubocop (1.23.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.11.1'.freeze
+    VERSION = '6.11.2'.freeze
   end
 end


### PR DESCRIPTION
#### Why

This adds a concurrency group to GitHub Actions workflows.

More info on what it is can be found [here](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency)
