### PR TITLE
Add cop for disallowing RecursiveOpenStruct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.11.3 - 2021-11-26
+### Changed
+- Disallow usage of `RecursiveOpenStruct` which inherits from `OpenStruct`. `OpenStruct` was disallowed in 6.11.0. Both of these classes introduce security risks and should not be used.
+
 ## 6.11.2 - 2021-11-19
 ### Changed
 - Add concurrenty to GitHub Actions workflow

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.11.2)
+    ws-style (6.11.3)
       rubocop (>= 1.12.1)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)
@@ -96,4 +96,4 @@ DEPENDENCIES
   ws-style!
 
 BUNDLED WITH
-   2.2.30
+   2.2.31

--- a/core.yml
+++ b/core.yml
@@ -5,6 +5,7 @@ require:
   - rubocop-performance
   - rubocop-rspec
   - rubocop-vendor
+  - ./lib/ws/style/recursive_open_struct_use.rb
 
 inherit_mode:
   merge:

--- a/lib/ws/style.rb
+++ b/lib/ws/style.rb
@@ -1,5 +1,6 @@
 require "ws/style/version"
 require "ws/style/inflector"
+require "ws/style/recursive_open_struct_use"
 
 module Ws
   module Style

--- a/lib/ws/style/recursive_open_struct_use.rb
+++ b/lib/ws/style/recursive_open_struct_use.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Ws
+  module Style
+    # This cop flags uses of RecursiveOpenStruct. RecursiveOpenStruct is a library used in the
+    # Wealthsimple ecosystem that is being phased out due to security issues.
+    #
+    # RecrusiveOpenStruct inherits from OpenStruct, which is now officially discouraged to be used
+    # for performance, version compatibility, and security issues.
+    #
+    # @safety
+    #
+    #   Note that this cop may flag false positives; for instance, the following legal
+    #   use of a hand-rolled `RecursiveOpenStruct` type would be considered an offense:
+    #
+    #   ```
+    #   module MyNamespace
+    #     class RecursiveOpenStruct # not the RecursiveOpenStruct we're looking for
+    #     end
+    #
+    #     def new_struct
+    #       RecursiveOpenStruct.new # resolves to MyNamespace::RecursiveOpenStruct
+    #     end
+    #   end
+    #   ```
+    #
+    # @example
+    #
+    #   # bad
+    #   point = RecursiveOpenStruct.new(x: 0, y: 1)
+    #
+    #   # good
+    #   Point = Struct.new(:x, :y)
+    #   point = Point.new(0, 1)
+    #
+    #   # also good
+    #   point = { x: 0, y: 1 }
+    #
+    #   # bad
+    #   test_double = RecursiveOpenStruct.new(a: 'b')
+    #
+    #   # good (assumes test using rspec-mocks)
+    #   test_double = double
+    #   allow(test_double).to receive(:a).and_return('b')
+    #
+    class RecursiveOpenStructUse < RuboCop::Cop::Base
+      MSG = <<~MSG.strip
+        Avoid using `RecursiveOpenStruct`; use `Struct`, `Hash`, a class or test doubles instead.
+      MSG
+
+      # @!method uses_recursive_open_struct?(node)
+      def_node_matcher :uses_recursive_open_struct?, <<-PATTERN
+          (const {nil? (cbase)} :RecursiveOpenStruct)
+      PATTERN
+
+      def on_const(node)
+        return unless uses_recursive_open_struct?(node)
+        return if custom_class_or_module_definition?(node)
+
+        add_offense(node)
+      end
+
+      private
+
+      def custom_class_or_module_definition?(node)
+        parent = node.parent
+
+        (parent.class_type? || parent.module_type?) && node.left_siblings.empty?
+      end
+    end
+  end
+end

--- a/lib/ws/style/recursive_open_struct_use.rb
+++ b/lib/ws/style/recursive_open_struct_use.rb
@@ -5,7 +5,7 @@ module Ws
     # This cop flags uses of RecursiveOpenStruct. RecursiveOpenStruct is a library used in the
     # Wealthsimple ecosystem that is being phased out due to security issues.
     #
-    # RecrusiveOpenStruct inherits from OpenStruct, which is now officially discouraged to be used
+    # RecursiveOpenStruct inherits from OpenStruct, which is now officially discouraged to be used
     # for performance, version compatibility, and security issues.
     #
     # @safety

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.11.2'.freeze
+    VERSION = '6.11.3'.freeze
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,14 @@
 require 'bundler/setup'
 require 'ws/style'
 
+require 'rubocop/rspec/support'
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
+
+  # Include RuboCop RSpec Matchers
+  config.include RuboCop::RSpec::ExpectOffense
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/spec/ws/style/recursive_open_struct_use_spec.rb
+++ b/spec/ws/style/recursive_open_struct_use_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe Ws::Style::RecursiveOpenStructUse, :config do
+  context 'when using RecursiveOpenStruct' do
+    ['RecursiveOpenStruct', '::RecursiveOpenStruct'].each do |klass|
+      context "for #{klass}" do
+        context 'when used in assignments' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, klass: klass)
+              a = %{klass}.new(a: 42)
+                  ^{klass} Avoid using `RecursiveOpenStruct`;[...]
+            RUBY
+          end
+        end
+
+        context 'when inheriting from it via <' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, klass: klass)
+              class SubClass < %{klass}
+                               ^{klass} Avoid using `RecursiveOpenStruct`;[...]
+              end
+            RUBY
+          end
+        end
+
+        context 'when inheriting from it via Class.new' do
+          it 'registers an offense' do
+            expect_offense(<<~RUBY, klass: klass)
+              SubClass = Class.new(%{klass})
+                                   ^{klass} Avoid using `RecursiveOpenStruct`;[...]
+            RUBY
+          end
+        end
+      end
+    end
+  end
+
+  context 'when using custom namespaced RecursiveOpenStruct' do
+    context 'when inheriting from it' do
+      specify { expect_no_offenses('class A < SomeNamespace::RecursiveOpenStruct; end') }
+    end
+
+    context 'when defined in custom namespace' do
+      context 'when class' do
+        specify do
+          expect_no_offenses(<<~RUBY)
+            module SomeNamespace
+              class RecursiveOpenStruct
+              end
+            end
+          RUBY
+        end
+      end
+
+      context 'when module' do
+        specify do
+          expect_no_offenses(<<~RUBY)
+            module SomeNamespace
+              module RecursiveOpenStruct
+              end
+            end
+          RUBY
+        end
+      end
+    end
+
+    context 'when used in assignments' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          a = SomeNamespace::RecursiveOpenStruct.new
+        RUBY
+      end
+    end
+  end
+
+  context 'when not using RecursiveOpenStruct' do
+    it 'registers no offense', :aggregate_failures do
+      expect_no_offenses('class A < B; end')
+      expect_no_offenses('a = 42')
+    end
+  end
+end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

`RecursiveOpenStruct` comes from a gem that we use in almost all of our Ruby apps. It inherits from `OpenStruct`. 

The most recent version of Rubocop reccomends against the use of `OpenStruct`. Ruby's own documentation gives a number of reasons not to use an `OpenStruct`, most notably the risk of a denial of service attack or the ability to overwrite methods: https://ruby-doc.org/stdlib-3.0.1/libdoc/ostruct/rdoc/OpenStruct.html#class-OpenStruct-label-Caveats

Removing our usage of `RecursiveOpenStruct` and `OpenStruct` is a huge task. As a first step, this PR introduces a rule that disallows `RecursiveOpenStruct` so that we prevent developers from introducing more usage of this class.

You can find more discussion here: https://wealthsimple.slack.com/archives/C0DSPV6E8/p1637791541378900

#### What changed <!-- Summary of changes when modifying hundreds of lines -->

Disallow the usage of `RecursiveOpenStruct`.

This code is a copy of Rubocop's own rule for disallowing OpenStruct: https://github.com/rubocop/rubocop/pull/10217/files

### How I tested
Updated `cs-tools` to use this branch of `ws-style` and then saw that it caused the PR to fail on the `lint` step.

https://github.com/wealthsimple/cs-tools/runs/4337177138?check_suite_focus=true

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
