### PR TITLE
disable Layout/ArgumentAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 6.11.3 - 2021-11-19
 ### Changed
-- Disable Layout/ArgumentAlignment
+- Layout/ArgumentAlignment uses with_fixed_indentation
 
 ## 6.11.2 - 2021-11-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.11.3 - 2021-11-19
+### Changed
+- Disable Layout/ArgumentAlignment
+
 ## 6.11.2 - 2021-11-19
 ### Changed
 - Add concurrenty to GitHub Actions workflow

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.11.2)
+    ws-style (6.11.3)
       rubocop (>= 1.12.1)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)
@@ -33,7 +33,7 @@ GEM
       thor (~> 0.20)
     minitest (5.14.4)
     parallel (1.21.0)
-    parser (3.0.2.0)
+    parser (3.0.3.1)
       ast (~> 2.4.1)
     rack (2.2.3)
     rainbow (3.0.0)
@@ -96,4 +96,4 @@ DEPENDENCIES
   ws-style!
 
 BUNDLED WITH
-   2.2.30
+   2.2.32

--- a/core.yml
+++ b/core.yml
@@ -35,7 +35,7 @@ Lint/AmbiguousBlockAssociation:
     - "spec/**/*"
 
 Layout/ArgumentAlignment:
-  Enabled: false
+  EnforcedStyle: with_fixed_indentation
 
 Layout/DotPosition:
   EnforcedStyle: trailing

--- a/core.yml
+++ b/core.yml
@@ -34,6 +34,9 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - "spec/**/*"
 
+Layout/ArgumentAlignment:
+  Enabled: false
+
 Layout/DotPosition:
   EnforcedStyle: trailing
 

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.11.2'.freeze
+    VERSION = '6.11.3'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

https://github.com/wealthsimple/ws-style/pull/72/files enabled `Layout/ArgumentAlignment`

However the cop has two different patterns which are both used at WS.
cash-service for example follows the `with_fixed_indentation` pattern instead of `with_first_argument`.

https://app.circleci.com/pipelines/github/wealthsimple/cash-service/11816/workflows/544309fa-113b-496e-8c29-0deb5f420c6d/jobs/95294

#### What changed <!-- Summary of changes when modifying hundreds of lines -->

disable `Layout/ArgumentAlignment`
    