### PR TITLE
Update rubocop-vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.12.0 - 2021-12-06
+- Update `rubocop-vendor`, which disallows `recursive-open-struct`
+
 ## 6.11.3 - 2021-11-19
 ### Changed
 - Layout/ArgumentAlignment uses with_fixed_indentation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.11.3)
+    ws-style (6.12.0)
       rubocop (>= 1.12.1)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)
@@ -39,7 +39,7 @@ GEM
     rainbow (3.0.0)
     rake (13.0.6)
     rchardet (1.8.0)
-    regexp_parser (2.1.1)
+    regexp_parser (2.2.0)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -63,7 +63,7 @@ GEM
       rubocop-ast (>= 1.12.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.13.0)
+    rubocop-ast (1.14.0)
       parser (>= 3.0.1.1)
     rubocop-performance (1.12.0)
       rubocop (>= 1.7.0, < 2.0)
@@ -74,7 +74,7 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
     rubocop-rspec (2.6.0)
       rubocop (~> 1.19)
-    rubocop-vendor (0.6.1)
+    rubocop-vendor (0.7.0)
       rubocop (>= 0.53.0)
     ruby-progressbar (1.11.0)
     thor (0.20.3)

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.11.3'.freeze
+    VERSION = '6.12.0'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

We updated `rubocop-vendor` to disallow `recursive-open-struct`: https://github.com/wealthsimple/rubocop-vendor/pull/14

#### What changed <!-- Summary of changes when modifying hundreds of lines -->

Update the Gemfile.lock to include this new version.

Additional details can be found in #77 


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
