### PR TITLE
fix: disable RequireMFA cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.12.1 - 2021-12-09
+### Changed
+- Disable new Gemspec/RequireMFA cop
+
 ## 6.12.0 - 2021-12-06
 - Update `rubocop-vendor`, which disallows `recursive-open-struct`
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.12.0)
+    ws-style (6.12.1)
       rubocop (>= 1.12.1)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)
@@ -96,4 +96,4 @@ DEPENDENCIES
   ws-style!
 
 BUNDLED WITH
-   2.2.32
+   2.2.33

--- a/core.yml
+++ b/core.yml
@@ -442,7 +442,7 @@ Gemspec/DateAssignment:
   Enabled: True
 
 # rubocop 1.23
-Gemspec/RequireMFA
+Gemspec/RequireMFA:
   Enabled: False
 
 Style/HashConversion:

--- a/core.yml
+++ b/core.yml
@@ -441,6 +441,10 @@ Style/IfWithBooleanLiteralBranches:
 Gemspec/DateAssignment:
   Enabled: True
 
+# rubocop 1.23
+Gemspec/RequireMFA
+  Enabled: False
+
 Style/HashConversion:
   Enabled: True
 

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.12.0'.freeze
+    VERSION = '6.12.1'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
Rubocop added a new Gemspec/RequireMFA cop. This is not necessary for most of our libraries since they are private and pushed to Nexus.

#### What changed <!-- Summary of changes when modifying hundreds of lines -->
- Disabled Gemspec/RequireMFA cop


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
