### PR TITLE
bumps rubocop dependency to 1.23 due to introduction of Gemspec/RequireMFA cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.12.2 - 2021-12-16
+### Changed
+- Upgraded rubocop to 1.23
+
 ## 6.12.1 - 2021-12-09
 ### Changed
 - Disable new Gemspec/RequireMFA cop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.12.1)
+    ws-style (6.12.2)
       rubocop (>= 1.23)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ws-style (6.12.1)
-      rubocop (>= 1.12.1)
+      rubocop (>= 1.23)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)
       rubocop-rspec (>= 2.2.0)

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.12.1'.freeze
+    VERSION = '6.12.2'.freeze
   end
 end

--- a/ws-style.gemspec
+++ b/ws-style.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.7.2'
 
-  s.add_dependency 'rubocop', '>= 1.12.1'
+  s.add_dependency 'rubocop', '>= 1.23'
   s.add_dependency 'rubocop-performance', '>= 1.10.2'
   s.add_dependency 'rubocop-rails', '>= 2.9.1'
   s.add_dependency 'rubocop-rspec', '>= 2.2.0'


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

As this rule exists (even though it's set to `false`), rubocop won't run unless it's at `1.23`.

https://github.com/wealthsimple/ws-style/blob/main/core.yml#L444-L446

![image](https://user-images.githubusercontent.com/191691/146467073-1d83913f-d315-4b24-b984-84930d46901c.png)

