### PR TITLE
disable enforcing shorthand syntax in ruby 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.13.1 - 2021-01-07
+### Changed
+- Disable ruby 3.1 Hash shorthand syntax
+
 ## 6.13.0 - 2021-01-04
 ### Changed
 - Updated rubocop to 1.24.1 and opted into new cops

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.13.0)
+    ws-style (6.13.1)
       rubocop (>= 1.23)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)
@@ -11,7 +11,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.0)
+    activesupport (7.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)

--- a/core.yml
+++ b/core.yml
@@ -560,6 +560,9 @@ Style/FileWrite:
 Style/MapToHash:
   Enabled: True
 
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never
+
 # rubocop-rspec 2.7
 RSpec/FactoryBot/SyntaxMethods:
   Enabled: false

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.13.0'.freeze
+    VERSION = '6.13.1'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
Ruby 3.1 introduces a new shorthand syntax for hashes

```
foo = 'bar'

{ foo: foo }

With ruby 3.1
{ foo: }
```

Disabling enforcing this rule
#### What changed <!-- Summary of changes when modifying hundreds of lines -->



<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
