### PR TITLE
disable Rails/RedundantPresenceValidationOnBelongsTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.13.3 - 2021-01-10
+### Changed
+- Disable Rails/RedundantPresenceValidationOnBelongsTo as it can generate unsafe autocorrections
+
 ## 6.13.2 - 2021-01-10
 ### Changed
 - Update rubocop-rails to 2.13.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.13.2)
+    ws-style (6.13.3)
       rubocop (>= 1.23)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)
@@ -35,7 +35,7 @@ GEM
     parser (3.1.0.0)
       ast (~> 2.4.1)
     rack (2.2.3)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     rake (13.0.6)
     rchardet (1.8.0)
     regexp_parser (2.2.0)

--- a/core.yml
+++ b/core.yml
@@ -565,4 +565,4 @@ Style/HashSyntax:
 
 # rubocop-rspec 2.7
 RSpec/FactoryBot/SyntaxMethods:
-  Enabled: false
+  Enabled: False

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.13.2'.freeze
+    VERSION = '6.13.3'.freeze
   end
 end

--- a/rails.yml
+++ b/rails.yml
@@ -103,7 +103,7 @@ Rails/DurationArithmetic:
   Enabled: True
 
 Rails/RedundantPresenceValidationOnBelongsTo:
-  Enabled: True
+  Enabled: False
 
 Rails/RootJoinChain:
   Enabled: True


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

Rails/RedundantPresenceValidationOnBelongsTo was opted in, in the last election.

However, the rule will detect an offense in cases of validations with custom messages.
Autocorrect will also remove the validation, which could break untested code.

e.g 

```
validates :account, presence: {
    message: ErrorSerializer.create_error(:WPSE000001),
 }
```
should be valid.

#### What changed <!-- Summary of changes when modifying hundreds of lines -->

Set Rails/RedundantPresenceValidationOnBelongsTo to false

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
