### PR TITLE
ci: update or add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/stale@v4
         with:
           days-before-stale: 30
-          days-before-close: 60
+          days-before-close: 30
           stale-pr-message: >
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.13.15 - 2022-04-01
+### Changed
+- Updated dependencies
+
 ## 6.13.14 - 2022-03-28
 ### Changed
 - Updated dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.13.14)
+    ws-style (6.13.15)
       rubocop (>= 1.23)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)
@@ -94,4 +94,4 @@ DEPENDENCIES
   ws-style!
 
 BUNDLED WITH
-   2.2.33
+   2.3.10

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.13.14'.freeze
+    VERSION = '6.13.15'.freeze
   end
 end


### PR DESCRIPTION
### Why
We want to reduce the default amount of time it takes to close PRs that have been marked as `stale`, from 60 days to 30 days.

The stale workflow uses GitHub Actions to automatically mark PRs as stale and eventually close them if there is no detected activity. This workflow excludes any dependency or security PRs.

For more information about the stale GitHub Action see: https://github.com/actions/stale

### What changed
* Add @wealthsimple/developer-tools as a CODEOWNER for all GitHub Actions workflows (if applicable)
* If this repo has an existing `stale.yml` workflow, reduce the `days-before-close` from 60 to 30 (if applicable)
* If this repo _does not_ have a `stale.yml' workflow, add one!

:warning: **This PR was opened automatically!** :warning: Please reach out in #developer-tools on Slack if you have any questions!