### PR TITLE
fix: update obsolete parameter IgnoredPatterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.13.21 - 2022-05-04
+### Changed
+- Updated obsolete parameter as per rubocop/rubocop#10555
+
 ## 6.13.20 - 2022-05-02
 ### Changed
 - Updated dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.13.20)
+    ws-style (6.13.21)
       rubocop (>= 1.23)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)

--- a/core.yml
+++ b/core.yml
@@ -60,7 +60,7 @@ Layout/IndentationWidth:
   Width: 2
 
 Layout/LineLength:
-  IgnoredPatterns: ['(\A|\s)#']
+  AllowedPatterns: ['(\A|\s)#']
   Max: 100
 
 Layout/FirstHashElementIndentation:

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.13.20'.freeze
+    VERSION = '6.13.21'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
I noticed this when rubocop started giving this warning:
```
Warning: obsolete parameter `IgnoredPatterns` (for `Layout/LineLength`) found in /Users/michael.belzil/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/ws-style-6.13.20/core.yml
`IgnoredPatterns` has been renamed to `AllowedPatterns`.
```

#### What changed <!-- Summary of changes when modifying hundreds of lines -->
`IgnoredPatterns` is now called `AllowedPatterns`

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
