### PR TITLE
fix: remove date assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.13.24 - 2022-06-27
+### Changed
+- Replaced Gemspec/DateAssignment with Gemspec/DeprecatedAttributesAssignment
+
 ## 6.13.23 - 2022-05-16
 ### Changed
 - Updated dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    ws-style (6.13.23)
-      rubocop (>= 1.23)
+    ws-style (6.13.24)
+      rubocop (>= 1.30)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)
       rubocop-rspec (>= 2.2.0)
@@ -30,7 +30,7 @@ GEM
     keepachangelog (0.6.1)
       json (~> 2.1)
       thor (~> 0.20)
-    minitest (5.16.0)
+    minitest (5.16.1)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -53,7 +53,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    rubocop (1.30.1)
+    rubocop (1.31.0)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -67,7 +67,7 @@ GEM
     rubocop-performance (1.14.2)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.15.0)
+    rubocop-rails (2.15.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
@@ -79,7 +79,7 @@ GEM
     thor (0.20.3)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.1.0)
+    unicode-display_width (2.2.0)
 
 PLATFORMS
   ruby
@@ -94,4 +94,4 @@ DEPENDENCIES
   ws-style!
 
 BUNDLED WITH
-   2.3.12
+   2.3.16

--- a/core.yml
+++ b/core.yml
@@ -437,8 +437,8 @@ Lint/TripleQuotes:
 Style/IfWithBooleanLiteralBranches:
   Enabled: False
 
-# rubocop 1.10
-Gemspec/DateAssignment:
+# rubocop 1.30
+Gemspec/DeprecatedAttributeAssignment:
   Enabled: True
 
 # rubocop 1.23

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.13.23'.freeze
+    VERSION = '6.13.24'.freeze
   end
 end

--- a/ws-style.gemspec
+++ b/ws-style.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.7.2'
 
-  s.add_dependency 'rubocop', '>= 1.23'
+  s.add_dependency 'rubocop', '>= 1.30'
   s.add_dependency 'rubocop-performance', '>= 1.10.2'
   s.add_dependency 'rubocop-rails', '>= 2.9.1'
   s.add_dependency 'rubocop-rspec', '>= 2.2.0'


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
Gemspec/DateAssignment was removed in Rubocop 1.31, so we need to replace it with Gemspec/DeprecatedAttributeAssignment.


#### What changed <!-- Summary of changes when modifying hundreds of lines -->
- Replaced Gemspec/DateAssignment with Gemspec/DeprecatedAttributeAssignment
- Require Rubocop >= 1.30 since that is when Gemspec/DeprecatedAttributeAssignment was added


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
