### PR TITLE
AllCops rule can only be defined once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.14.1 - 2022-09-14
+### Changed
+- NewCops rule can only be defined once.
+
 ## 6.14.0 - 2022-09-6
 ### Changed
 - Support new rules introduced between rubocop 1.26 -> 1.36

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.14.0)
+    ws-style (6.14.1)
       rubocop (>= 1.36)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)
@@ -76,15 +76,15 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
-    rubocop-rspec (2.12.1)
-      rubocop (~> 1.31)
+    rubocop-rspec (2.13.1)
+      rubocop (~> 1.33)
     rubocop-vendor (0.8.10)
       rubocop (>= 0.53.0)
     ruby-progressbar (1.11.0)
     thor (0.20.3)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.2.0)
+    unicode-display_width (2.3.0)
 
 PLATFORMS
   ruby

--- a/core.yml
+++ b/core.yml
@@ -13,8 +13,6 @@ inherit_mode:
 
 AllCops:
   NewCops: disable
-
-AllCops:
   Exclude:
     - "bin/**/*"
     - "data/**/*"

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.14.0'.freeze
+    VERSION = '6.14.1'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
Fixing bug where the AllCops rule was defined twice, causing the first one to be ignored.


#### What changed <!-- Summary of changes when modifying hundreds of lines -->



<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
