### PR TITLE
Bump version to capture a bunch of depfu updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.15.0 - 2022-10-05
+### Changed
+- Updated dependencies in previous PRs
+  - rspec-expectations (indirect, 3.11.0 → 3.11.1, patch)
+  - rspec-support (indirect, 3.11.0 → 3.11.1, patch)
+  - rubocop-rails (2.16.0 → 2.16.1, patch)
+  - rubocop-rspec (2.13.1 → 2.13.2, patch)
+  - regexp_parser (indirect, 2.5.0 → 2.6.0, minor)
+
 ## 6.14.1 - 2022-09-14
 ### Changed
 - NewCops rule can only be defined once.

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.14.1'.freeze
+    VERSION = '6.15.0'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
Bumping version to capture dependency changes from:
- https://github.com/wealthsimple/ws-style/pull/132
- https://github.com/wealthsimple/ws-style/pull/133
- https://github.com/wealthsimple/ws-style/pull/134

#### What changed <!-- Summary of changes when modifying hundreds of lines -->
- bumping to v6.15.0

#### How I tested [ Bullets for test cases covered ]
- CI
<!--
Consider adding the following sections:


#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
