### PR TITLE
Add Strict Dry Struct custom rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## 6.14.4 - 2023-01-03
+### Changed
+- Added custom rule Ws/StrictDryStruct
 
 ## 6.14.3 - 2023-01-03
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.14.3)
+    ws-style (6.14.4)
       rubocop (>= 1.36)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)

--- a/core.yml
+++ b/core.yml
@@ -5,6 +5,7 @@ require:
   - rubocop-performance
   - rubocop-rspec
   - rubocop-vendor
+  - ./lib/ws/strict_dry_struct.rb
 
 inherit_mode:
   merge:

--- a/lib/ws/strict_dry_struct.rb
+++ b/lib/ws/strict_dry_struct.rb
@@ -1,0 +1,20 @@
+module Ws
+  class StrictDryStruct < RuboCop::Cop::Base
+    MSG = 'Avoid using `Dry::Struct` without schema schema.strict'.freeze
+
+    def_node_matcher :uses_open_struct?, <<-PATTERN
+      (const (const {nil? (cbase)} :Dry) :Struct)
+    PATTERN
+
+    def_node_search :uses_strict_mode?, <<-PATTERN
+      (send nil? :schema (send (send nil? :schema) :strict))
+    PATTERN
+
+    def on_const(node)
+      return unless uses_open_struct?(node)
+      return if uses_strict_mode?(node.parent)
+
+      add_offense(node)
+    end
+  end
+end

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.14.3'.freeze
+    VERSION = '6.14.4'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

If strict mode is not enabled an error will not be raised when building a struct with incorrect keys. This can lead to bugs if a typo is present.
See: https://wealthsimple.slack.com/archives/C19UB3HNZ/p1673987597622649

#### What changed <!-- Summary of changes when modifying hundreds of lines -->

We now have a new cop which will guard against using Dry::Struct without strict mode!

<img width="912" alt="egoodwin-wealthsimple-2023-01-19 at 09 28 39@2x" src="https://user-images.githubusercontent.com/2047/213517428-dcc2084d-1011-4aa5-8658-3a6772e69b79.png">

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
