### PR TITLE
feat: remove toolbox-script

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,7 +21,7 @@ jobs:
         run: git fetch origin main
       - uses: r7kamura/rubocop-problem-matchers-action@v1
       - name: Lint
-        run:
+        run: |
           bundle exec rubocop
           bundle exec bundle-audit update
           bundle exec bundle-audit check

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Fetch main branch
         run: git fetch origin main
       - uses: r7kamura/rubocop-problem-matchers-action@v1
-        name: Lint
+      - name: Lint
         run:
           bundle exec rubocop
           bundle exec bundle-audit update

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -20,10 +20,11 @@ jobs:
       - name: Fetch main branch
         run: git fetch origin main
       - uses: r7kamura/rubocop-problem-matchers-action@v1
-      - uses: wealthsimple/toolbox-script@main
-        name: RuboCop
-        with:
-          script: toolbox.ruby.lint.run()
+        name: Lint
+        run:
+          bundle exec rubocop
+          bundle exec bundle-audit update
+          bundle exec bundle-audit check
       - name: Run rspec
         run: bundle exec rspec
       - name: Release the gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 6.14.5 - 2023-02-23
+### Changed
+- Remove use of toolbox-script in Github workflows
+
 ## 6.14.4 - 2023-01-31
 ### Changed
 - Upgraded to ruby 3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.14.4)
+    ws-style (6.14.5)
       rubocop (>= 1.36)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.14.4'.freeze
+    VERSION = '6.14.5'.freeze
   end
 end


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
Github Actions can now be stored in private repos. We want to make toolbox-script private. Only private repos can access private Github Actions. Therefore we need to stop using toolbox-script in this public repo if we want to make toolbox-script private. This updates this repo to be more in line with the tooling in our other public repos.


#### What changed <!-- Summary of changes when modifying hundreds of lines -->
- Removed usage of toolbox-script
