### PR TITLE
Address rubocop-rspec 2.22 warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 6.14.7 - 2023-05-10
+### Changed
+- Address rubocop warnings
+
 ## 6.14.6 - 2023-04-28
 ### Changed
 - Removed support for Ruby 2 since it is EOL

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (6.14.6)
+    ws-style (6.14.7)
       rubocop (>= 1.36)
       rubocop-performance (>= 1.10.2)
       rubocop-rails (>= 2.9.1)

--- a/core.yml
+++ b/core.yml
@@ -568,10 +568,6 @@ Style/MapToHash:
 Style/HashSyntax:
   EnforcedShorthandSyntax: never
 
-# rubocop-rspec 2.7
-RSpec/FactoryBot/SyntaxMethods:
-  Enabled: False
-
 # rubocop 1.26
 Style/NestedFileDirname:
   Enabled: True
@@ -634,9 +630,6 @@ RSpec/ChangeByZero:
   Enabled: True
 
 # rubocop-rspec 2.12
-RSpec/Capybara/SpecificMatcher:
-  Enabled: False
-
 RSpec/Rails/HaveHttpStatus:
   Enabled: True
 
@@ -646,3 +639,10 @@ RSpec/BeEq:
 
 RSpec/BeNil:
   Enabled: True
+
+# rubocop-rspec 2.22
+Capybara/SpecificMatcher:
+  Enabled: False
+
+FactoryBot/SyntaxMethods:
+  Enabled: False

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '6.14.6'.freeze
+    VERSION = '6.14.7'.freeze
   end
 end


### PR DESCRIPTION
Addresses rubocop warnings:

<img width="859" alt="image" src="https://github.com/wealthsimple/ws-style/assets/191691/d35870ca-15f9-4d0f-9450-cb34a883ae2e">
