### PR TITLE
chore: added gitleaks as a pre-commit step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 7.1.1 - 2023-06-19
+### Changed
+- Added Gitleaks as a pre-commit step
+
 ## 7.1.0 - 2023-06-01
 ### Changed
 - Update rubocop-vendor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (7.1.0)
+    ws-style (7.1.1)
       rubocop-rspec (>= 2.2.0)
       rubocop-vendor (>= 0.11)
       standard (>= 1.28.2)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,6 @@
+# Lefthook is used for configuring git hooks such as pre-commit, pre-push, etc.
+# Can read more here: https://github.com/evilmartians/lefthook
+pre-commit:
+  commands:
+    gitleaks:
+      run: gitleaks protect --verbose --redact --staged

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '7.1.0'.freeze
+    VERSION = '7.1.1'.freeze
   end
 end


### PR DESCRIPTION
## Why

Hello, we on Security Tools have set up a new tool to help prevent credentials getting committed into our Git repositories. There have been quite a few incidents of credentials being pushed in the clear into WS repos, and we are working to help prevent this inadvertent disclosure.

We're looking to help prevent this by leveraging a pre-commit scanning operation that utilizes [Gitleaks](https://github.com/gitleaks/gitleaks) with some customizations on top of it.

We've worked with some folks on Developer Tools to figure out the best way to manage this tool, and we have a CLI that can be installed here: https://github.com/wealthsimple/cli#installation. Doing so will install the necessary dependencies through homebrew, and setup our own Gitleaks configuration on your system.

For more information on setting up and using this tool, we have more documentation found here: https://www.notion.so/wealthsimple/Gitleaks-42fc7f2134404a56ab53fb3c1140843b. Including a link to the project brief.

## What Changed

To manage the installation of Git Hooks, we're using a tool called Lefthook: https://github.com/evilmartians/lefthook. Lefthook is a platform agnostic solution for this, and allows things like parallelization. The changes in this PR include adding a yaml file to configure Lefthook to run Gitleaks for us.

Lefthook is also installed on your system through homebrew when you follow the installation steps for `ws-cli`. Installing `ws-cli` will provide you with a zsh/bash chdir hook so that when a Lefthook file is found, `lefthook install` will be run automatically for you.

## Troubleshooting

If you run into any challenges with this new tooling or have any feedback, please reach out to us in [#proj-credentials-scanning-prevention](https://wealthsimple.slack.com/archives/C04LR3HVAA3) on Slack.
