### PR TITLE
Fix disabled rubocop-rspec and rubocop-vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 7.2.0 - 2023-07-14
+### Changed
+- Fix issue where rubocop-rspec was disabled by default after the switch to standardrb
+
 ## 7.1.3 - 2023-07-14
 ### Changed
 - Added SECURITY.md file

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (7.1.3)
+    ws-style (7.2.0)
       rubocop-rspec (>= 2.2.0)
       rubocop-vendor (>= 0.11)
       standard (>= 1.30.1)

--- a/core.yml
+++ b/core.yml
@@ -29,7 +29,6 @@ AllCops:
     - "db/migrate/**/*"
     - "db/schema.rb"
     - "gemfiles/**/*"
-    - "lib/tasks/circle_0.rake"
     - "log/**/*"
     - "node_modules/**/*"
     - "public/**/*"
@@ -72,3 +71,7 @@ Style/TrailingCommaInArguments:
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
+
+# enable rubocop-vendor
+Vendor:
+  Enabled: true

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '7.1.3'.freeze
+    VERSION = '7.2.0'.freeze
   end
 end

--- a/rspec.yml
+++ b/rspec.yml
@@ -1,6 +1,9 @@
 require:
   - rubocop-rspec
 
+RSpec:
+  Enabled: true
+
 # rubocop-rspec overrides
 RSpec/AnyInstance:
   Enabled: false


### PR DESCRIPTION
The switch to standardrb introduced the `DisabledByDefault: true` property configuration.
This inadvertently set the default state of rubocop-rspec and rubocop-vendor to disabled, as they now need to be explicitly enabled.