### PR TITLE
disable some contentious cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 7.3.0 - 2023-01-11
+### Changed
+- Disable some cops which don't add significant value
+
 ## 7.2.1 - 2023-11-28
 ### Changed
 - Support older versions of Ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (7.2.1)
+    ws-style (7.3.0)
       rubocop-rspec (>= 2.2.0)
       rubocop-vendor (>= 0.11)
       standard (>= 1.30.1)

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '7.2.1'.freeze
+    VERSION = '7.3.0'.freeze
   end
 end

--- a/rails.yml
+++ b/rails.yml
@@ -5,5 +5,11 @@ inherit_gem:
   standard-rails: config/base.yml
 
 # standard-rails overrides
+Rails/DynamicFindBy:
+  Enabled: false
+
 Rails/EnvironmentVariableAccess:
+  Enabled: false
+
+Rails/PluckId:
   Enabled: false

--- a/rspec.yml
+++ b/rspec.yml
@@ -23,6 +23,9 @@ RSpec/LetSetup:
 RSpec/MessageChain:
   Enabled: false
 
+RSpec/MessageSpies:
+  Enabled: false
+
 RSpec/MultipleExpectations:
   Enabled: false
 
@@ -34,3 +37,6 @@ RSpec/NamedSubject:
 
 RSpec/NestedGroups:
   Max: 6
+
+RSpec/StubbedMock:
+  Enabled: false


### PR DESCRIPTION
Suggestion: 

`Rails/DynamicFindBy`
Prevents usage of methods like `find_by_canonical_id(foo: :bar)`
This rule creates a lot of false positives on existing code bases, since we have methods on repository classes and our internal static-collection gem. 

`Rails/PluckId`
Suggests replacing ActiveRecord::Collection#pluck(:id) with ActiveRecord::Collection#ids.
Creates false positives as pluck(:value) is also used in the context of enumerable objects in ralis.

`RSpec/MessageSpies`/`RSpec/StubbedMock`
See some interesting discussion here:

https://github.com/rubocop/rubocop-rspec/issues/1271
https://www.hashnotadam.com/posts/2023/01/to-receive-or-have_received/ for a good explaination.

