### PR TITLE
fix incorrect factory_bot config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 7.4.1 - 2024-01-19
+### Changed
+- Fix incorrect factory bot configuration
+
 ## 7.4.0 - 2024-01-14
 ### Changed
 - Add rubocop-factory_bot

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (7.4.0)
-      rubocop-factory_bot (>= 2.25.1)
+    ws-style (7.4.1)
       rubocop-rspec (>= 2.2.0)
       rubocop-vendor (>= 0.11)
       standard (>= 1.30.1)

--- a/core.yml
+++ b/core.yml
@@ -11,7 +11,6 @@ require:
   - standard-custom
   - rubocop-performance
   - rubocop-vendor
-  - rubocop-factory_bot
 
 inherit_gem:
   standard: config/base.yml

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '7.4.0'.freeze
+    VERSION = '7.4.1'.freeze
   end
 end

--- a/rspec.yml
+++ b/rspec.yml
@@ -4,6 +4,9 @@ require:
 RSpec:
   Enabled: true
 
+FactoryBot:
+  Enabled: true
+
 # rubocop-rspec overrides
 RSpec/AnyInstance:
   Enabled: false

--- a/ws-style.gemspec
+++ b/ws-style.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'standard-rails', '>= 0.1.0'
   s.add_dependency 'rubocop-rspec', '>= 2.2.0'
   s.add_dependency 'rubocop-vendor', '>= 0.11'
-  s.add_dependency 'rubocop-factory_bot', '>= 2.25.1'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'bundler-audit'


### PR DESCRIPTION
Fix incorrect configuration of factory_bot.

It is already a dependency of rubocop-rspec, and only needs to be enabled.