### PR TITLE
Rubocop: Bulk Change Table rule is not useful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## 7.4.2 - 2024-01-26
 ### Changed
 - Disable `Rails/BulkChangeTable` rule

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 7.4.2 - 2024-01-26
+### Changed
+- Disable `Rails/BulkChangeTable` rule
 
 ## 7.4.1 - 2024-01-19
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (7.4.1)
+    ws-style (7.4.2)
       rubocop-rspec (>= 2.2.0)
       rubocop-vendor (>= 0.11)
       standard (>= 1.30.1)

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '7.4.1'.freeze
+    VERSION = '7.4.2'.freeze
   end
 end

--- a/rails.yml
+++ b/rails.yml
@@ -13,3 +13,6 @@ Rails/EnvironmentVariableAccess:
 
 Rails/PluckId:
   Enabled: false
+
+Rails/BulkChangeTable:
+  Enabled: false


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->

This [rule](https://www.rubydoc.info/gems/rubocop/0.61.1/RuboCop/Cop/Rails/BulkChangeTable) is not really useful.

Combine this with the fact that this syntax then requires `safety_assured` to be used, it makes it counter productive. 


#### What changed <!-- Summary of changes when modifying hundreds of lines -->

Disable `Rails/BulkChangeTable`

<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
