### PR TITLE
ignore migration directories in multi database monoliths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 7.4.4 - 2024-02-12
+### Changed
+- Ignore all migration folders in multi database
+
 ## 7.4.3 - 2024-02-12
 ### Changed
 - Updated rspec dependency

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (7.4.3)
+    ws-style (7.4.4)
       rubocop-rspec (>= 2.2.0)
       rubocop-vendor (>= 0.11)
       standard (>= 1.30.1)

--- a/core.yml
+++ b/core.yml
@@ -26,7 +26,7 @@ AllCops:
     - "bin/**/*"
     - "data/**/*"
     - "db/data/**/*"
-    - "db/migrate/**/*"
+    - "db/*migrate/**/*"
     - "db/schema.rb"
     - "gemfiles/**/*"
     - "log/**/*"

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '7.4.3'.freeze
+    VERSION = '7.4.4'.freeze
   end
 end


### PR DESCRIPTION
For merged services, the monolith has multiple migration directories.

E.g
/db/migrate/
/db/cash_migrate/

Ensure rubocop is ignored consistently for all directories.