### PR TITLE
disable some cops added in recent releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 7.6.0 - 2024-07-09
+### Changed
+- Disable some newer cops
+
 ## 7.5.1 - 2024-06-19
 ### Changed
 - Updated dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ws-style (7.5.1)
+    ws-style (7.6.0)
       rubocop-factory_bot (>= 2.26.0)
       rubocop-rspec (>= 3.0.0)
       rubocop-vendor (>= 0.11)
@@ -44,7 +44,7 @@ GEM
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
-    minitest (5.24.0)
+    minitest (5.24.1)
     mutex_m (0.2.0)
     parallel (1.25.1)
     parse_a_changelog (1.3.0)
@@ -56,12 +56,12 @@ GEM
     process_executer (1.1.0)
     public_suffix (6.0.0)
     racc (1.8.0)
-    rack (3.1.4)
+    rack (3.1.6)
     rainbow (3.1.1)
     rake (13.2.1)
     rchardet (1.8.0)
     regexp_parser (2.9.2)
-    rexml (3.3.0)
+    rexml (3.3.1)
       strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -94,17 +94,17 @@ GEM
     rubocop-performance (1.21.1)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rails (2.25.0)
+    rubocop-rails (2.25.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rspec (3.0.1)
+    rubocop-rspec (3.0.2)
       rubocop (~> 1.61)
     rubocop-vendor (0.13.0)
       rubocop
     ruby-progressbar (1.13.0)
-    standard (1.39.0)
+    standard (1.39.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
       rubocop (~> 1.64.0)
@@ -141,4 +141,4 @@ DEPENDENCIES
   ws-style!
 
 BUNDLED WITH
-   2.4.20
+   2.5.9

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '7.5.1'.freeze
+    VERSION = '7.6.0'.freeze
   end
 end

--- a/rails.yml
+++ b/rails.yml
@@ -16,3 +16,6 @@ Rails/PluckId:
 
 Rails/BulkChangeTable:
   Enabled: false
+
+Rails/WhereRange:
+  Enabled: false

--- a/rspec.yml
+++ b/rspec.yml
@@ -21,6 +21,9 @@ RSpec/EmptyExampleGroup:
 RSpec/ExampleLength:
   Max: 30
 
+RSpec/IndexedLet:
+  Enabled: false
+
 RSpec/LetSetup:
   Enabled: false
 
@@ -41,6 +44,9 @@ RSpec/NamedSubject:
 
 RSpec/NestedGroups:
   Max: 6
+
+RSpec/SpecFilePathFormat:
+  Enabled: false
 
 RSpec/StubbedMock:
   Enabled: false


### PR DESCRIPTION
Disable some cops added in recent versions of rubocop

https://docs.rubocop.org/rubocop-rails/cops_rails.html#railswhererange
The recommended usage of the range syntax isn't clearer and can lead to subtle bugs vs compared to > or >=

https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecindexedlet
🤷‍♂️ ok, but creating a ton of churn for existing specs.

https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecspecfilepathformat
This cop does not work with our components based directory structure.