### PR TITLE
Remove FactoryBot cop/department

### DIFF
--- a/rspec.yml
+++ b/rspec.yml
@@ -5,9 +5,6 @@ require:
 RSpec:
   Enabled: true
 
-FactoryBot:
-  Enabled: true
-
 # rubocop-rspec overrides
 RSpec/AnyInstance:
   Enabled: false


### PR DESCRIPTION
#### Why <!-- A short description of why this change is required -->
In the `ws-railway` 22.2.2, the `rubocop-factorybot` gem was removed. However, this rule was left in place, causing the `bundle exec rubocop` command to fail with the following error:

```
Error: unrecognized cop or department FactoryBot found in /Users/spejic/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/ws-style-7.4.4/rspec.yml
```

Removing the rule fixes the issue.

#### What changed <!-- Summary of changes when modifying hundreds of lines -->
✂️ 


<!--
Consider adding the following sections:

#### How I tested [ Bullets for test cases covered ]
#### Next steps [ If your PR is part of a few or a WIP, give context to reviewers ]
#### Screenshot [ An image is worth a thousand words ]
#### Bug/Ticket tracker [ Unnecessary when prefixing branch with JIRA ticket, e.g. SECURITY-123-human-readable-thing ]
-->
