### PR TITLE
switch to standard-rails fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 7.7.1 - 2024-03-17
+### Changed
+- Switch to standard-rails fork to upgrade rubocop-rails and resolve noisy warnings.
+
 ## 7.7.0 - 2024-03-12
 ### Changed
 - Use new plugins API, also supported by rubcop-vendor >= 0.14.2

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in ws-style.gemspec
 gemspec
+
+gem 'standard-rails', github: 'desheikh/standard-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,20 @@
+GIT
+  remote: https://github.com/desheikh/standard-rails.git
+  revision: c9f83ebe1a97191dcfc5ca69a6b7221c242937db
+  specs:
+    standard-rails (1.2.0)
+      lint_roller (~> 1.0)
+      rubocop-rails (~> 2.30.0)
+
 PATH
   remote: .
   specs:
-    ws-style (7.7.0)
+    ws-style (7.7.1)
       rubocop-factory_bot (>= 2.26.0)
       rubocop-rspec (>= 3.0.0)
       rubocop-vendor (>= 0.14.2)
       standard (>= 1.30.1)
       standard-custom (>= 1.0.2)
-      standard-rails (>= 0.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -89,7 +96,7 @@ GEM
       rubocop-ast (>= 1.38.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.38.1)
+    rubocop-ast (1.39.0)
       parser (>= 3.3.1.0)
     rubocop-factory_bot (2.27.0)
       lint_roller (~> 1.1)
@@ -98,11 +105,12 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
-    rubocop-rails (2.26.2)
+    rubocop-rails (2.30.3)
       activesupport (>= 4.2.0)
+      lint_roller (~> 1.1)
       rack (>= 1.1)
-      rubocop (>= 1.52.0, < 2.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
+      rubocop (>= 1.72.1, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
     rubocop-rspec (3.5.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
@@ -123,9 +131,6 @@ GEM
     standard-performance (1.7.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.24.0)
-    standard-rails (1.2.0)
-      lint_roller (~> 1.0)
-      rubocop-rails (~> 2.26.0)
     thor (1.3.2)
     treetop (1.6.14)
       polyglot (~> 0.3)
@@ -147,6 +152,7 @@ DEPENDENCIES
   parse_a_changelog
   rake
   rspec (~> 3.13.0)
+  standard-rails!
   ws-style!
 
 BUNDLED WITH

--- a/lib/ws/style/version.rb
+++ b/lib/ws/style/version.rb
@@ -1,5 +1,5 @@
 module Ws
   module Style
-    VERSION = '7.7.0'.freeze
+    VERSION = '7.7.1'.freeze
   end
 end

--- a/ws-style.gemspec
+++ b/ws-style.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'standard', '>= 1.30.1'
   s.add_dependency 'standard-custom', '>= 1.0.2'
-  s.add_dependency 'standard-rails', '>= 0.1.0'
+  # s.add_dependency 'standard-rails', '>= 0.1.0'
   s.add_dependency 'rubocop-rspec', '>= 3.0.0'
   s.add_dependency 'rubocop-factory_bot', '>= 2.26.0'
   s.add_dependency 'rubocop-vendor', '>= 0.14.2'


### PR DESCRIPTION
The current version of standard-rails is pinned to rubocop-rails 2.26 which generates a lot od noisy warnings in CI.

<img width="662" alt="image" src="https://github.com/user-attachments/assets/990f5340-076c-4fe9-8677-c356535dbe02" />

Switch to a fork, that updates rubocop-rails to ~> 2.30.x which [fixes](https://github.com/rubocop/rubocop-rails/blob/master/CHANGELOG.md#bug-fixes-2) the false warnings.
We can revert back to upstream when [this](https://github.com/standardrb/standard-rails/pull/69) PR get's released.